### PR TITLE
Disable email by default

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -11,7 +11,7 @@ smtpAuth: true
 useSSL: true
 
 #Should we turn the email feature off?
-disable_email: false
+disable_email: true
 
 
 #Twilio SMS setup


### PR DESCRIPTION
The initial email configuration is invalid and should be left as disabled until properly configured.